### PR TITLE
Adding simpson dataset to the original code base

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,179 @@
+# Created by https://www.toptal.com/developers/gitignore/api/python
+# Edit at https://www.toptal.com/developers/gitignore?templates=python
+
+### Python ###
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+cover/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+.pybuilder/
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+#   For a library or package, you might want to ignore these files since the code is
+#   intended to run in multiple environments; otherwise, check them in:
+# .python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# poetry
+#   Similar to Pipfile.lock, it is generally recommended to include poetry.lock in version control.
+#   This is especially recommended for binary packages to ensure reproducibility, and is more
+#   commonly ignored for libraries.
+#   https://python-poetry.org/docs/basic-usage/#commit-your-poetrylock-file-to-version-control
+#poetry.lock
+
+# pdm
+#   Similar to Pipfile.lock, it is generally recommended to include pdm.lock in version control.
+#pdm.lock
+#   pdm stores project-wide configurations in .pdm.toml, but it is recommended to not include it
+#   in version control.
+#   https://pdm.fming.dev/#use-with-ide
+.pdm.toml
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow and github.com/pdm-project/pdm
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# pytype static type analyzer
+.pytype/
+
+# Cython debug symbols
+cython_debug/
+
+# PyCharm
+#  JetBrains specific template is maintained in a separate JetBrains.gitignore that can
+#  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
+#  and can be added to the global gitignore or merged into this file.  For a more nuclear
+#  option (not recommended) you can uncomment the following to ignore the entire idea folder.
+#.idea/
+
+### Python Patch ###
+# Poetry local configuration file - https://python-poetry.org/docs/configuration/#local-configuration
+poetry.toml
+
+# ruff
+.ruff_cache/
+
+# LSP config files
+pyrightconfig.json
+
+# End of https://www.toptal.com/developers/gitignore/api/python
+
+
+data

--- a/dataset/__init__.py
+++ b/dataset/__init__.py
@@ -1,4 +1,4 @@
 from .dataset import *
 from .coco import *
 from .balloon import *
-from .simpson import SimpsonDemo, register_simpson
+from .simpson import *

--- a/dataset/__init__.py
+++ b/dataset/__init__.py
@@ -1,3 +1,4 @@
 from .dataset import *
 from .coco import *
 from .balloon import *
+from .simpson import *

--- a/dataset/__init__.py
+++ b/dataset/__init__.py
@@ -1,5 +1,4 @@
 from .dataset import *
 from .coco import *
 from .balloon import *
-from .simpson import SimpsonDemo, register_simpson
-
+from .simpson import *

--- a/dataset/__init__.py
+++ b/dataset/__init__.py
@@ -1,4 +1,4 @@
 from .dataset import *
 from .coco import *
 from .balloon import *
-from .simpson import *
+from .simpson import SimpsonDemo, register_simpson

--- a/dataset/__init__.py
+++ b/dataset/__init__.py
@@ -1,4 +1,5 @@
 from .dataset import *
 from .coco import *
 from .balloon import *
-from .simpson import *
+from .simpson import SimpsonDemo, register_simpson
+

--- a/dataset/parse_simpson.py
+++ b/dataset/parse_simpson.py
@@ -122,7 +122,7 @@ def process_annotations(
         }, fw, indent=4)
 
 
-def test_data_visuals(basedir, visualize_subfolder = 'temp_output'):
+def test_data_visuals(basedir, visualize_subfolder = 'temp_output', image_subfolder=IMAGE_SUBFOLDER):
     json_file = os.path.join(basedir, "annotations.json")
     with open(json_file) as f:
         obj = json.load(f)
@@ -131,7 +131,7 @@ def test_data_visuals(basedir, visualize_subfolder = 'temp_output'):
     #! This is for the draw_annotation function to know our classes
     cfg.DATA.CLASS_NAMES = class_names 
     
-    roidbs = SimpsonDemo(basedir, "train").training_roidbs()
+    roidbs = SimpsonDemo(basedir, "train", image_subfolder).training_roidbs()
 
     visualization_folder = os.path.join(basedir, visualize_subfolder)
     if not os.path.isdir(visualization_folder): os.mkdir(visualization_folder)

--- a/dataset/parse_simpson.py
+++ b/dataset/parse_simpson.py
@@ -1,0 +1,180 @@
+import math
+import random
+import argparse
+from viz import draw_annotation
+from PIL import Image
+import cv2
+import os
+from config import config as cfg
+from .simpson import SimpsonDemo
+import json 
+import numpy as np
+
+# Default configs
+CLASS_LIMIT = 99 # simpson dataset have 18 classes
+VALIDATION_SIZE = 0.5 # minium validation size for 19 classed to be validly trained
+BASE_DIR = './data/simpson'
+IMAGE_SUBFOLDER = 'simpsons_dataset'
+
+
+def split_train_val(all_imgs, classes_count, validation_size):
+    '''
+        This function will try balance of classes
+        1. train size is based on the count of the smallest class (class with least samples)
+            Meaning if train_size is 0.1 and smallest class have 10 samples then
+            -> We take 1 sample from each class of the training set
+        2. This ensure a kind-of-balance and uniform distribution
+        3. And also no empty training class samples
+    '''
+    min_size,  _ = max(zip(classes_count.values(), classes_count.keys()))
+    train_threshold = math.ceil((1 - validation_size) * min_size)
+    training_counter = {key : train_threshold for key in classes_count.keys()}
+    train = []
+    val = []
+    
+    image_keys = list(all_imgs.keys())
+    random.shuffle(image_keys)
+    for key in image_keys:
+        classname = all_imgs[key]['classname'][0]
+        if training_counter[classname] >= 0:
+            train.append(all_imgs[key])
+            training_counter[classname] -= 1
+        else:
+            val.append(all_imgs[key])
+
+    print(f'Classes count: {len(classes_count)}')
+    print(f'Train size: {len(train)}, validation size: {len(val)}')
+    return train, val
+
+'''
+    Parse annotation.txt and write to annotation.json with train/val split for easy
+        training without actually splitting the dataset into train/val folder
+
+    NOTE: process_annotations's
+        bounding box parsing is based on code from the following project
+    https://github.com/duckrabbits/ObjectDetection/blob/master/model/parser.py
+'''
+def process_annotations(
+        basedir, 
+        class_limit,
+        validation_size,
+        image_subfolder=IMAGE_SUBFOLDER
+    ):
+    print(f'Number of training classes limit: {class_limit}')   
+    print(f'Training size: {1 - validation_size}')
+    
+    annotation_file = os.path.join(basedir, "annotation.txt")
+    classes_count = {}
+    class_mapping = {}
+    all_imgs = {}
+
+    classes_count['BG'] = 0
+    class_mapping['BG'] = 0
+
+    with open(annotation_file,'r') as f:
+        for line in f:
+            line_split = line.strip().split(',')
+            (filename,x1,y1,x2,y2,class_name) = line_split
+            x1, y1, x2, y2 = [int(x) + 0.5 for x in [x1, y1, x2, y2]]
+
+            x1, x2 = min(x1,x2), max(x1,x2)
+            y1, y2 = min(y1,y2), max(y1,y2)
+            #! MAKE SURE BOUNDING BOX IS VALID
+            area = (x2 - x1) * (y2 - y1)
+
+            if area <= 0: continue
+            
+            #! Remove leading '/character' or '/character2' in filename
+            filename = '/'.join(filename.split('/')[2:])
+            filename = os.path.join(basedir, image_subfolder, filename) 
+
+
+
+            if class_name not in class_mapping:
+                if len(class_mapping) > class_limit: continue
+                class_mapping[class_name] = len(class_mapping)
+                # this means first class is 1, second is 2, ...
+            
+            # update class count
+            if class_name not in classes_count:
+                classes_count[class_name] = 1
+            else:
+                classes_count[class_name] += 1
+
+            if filename not in all_imgs:
+                all_imgs[filename] = {}
+                all_imgs[filename]['file_name'] = filename
+                all_imgs[filename]['boxes'] = [[x1,y1, x2, y2]]
+                all_imgs[filename]['class'] = [class_mapping[class_name]]
+                all_imgs[filename]['classname'] = [class_name]
+
+        train_meta, val_meta = split_train_val(all_imgs, classes_count, validation_size)
+
+    # write to file
+    with open(os.path.join(basedir, 'annotations.json'), 'w') as fw:
+        json.dump({
+            'classes' : {
+                'count' : classes_count,
+                'mapping' : class_mapping
+            },
+            'train': train_meta, 
+            'val': val_meta,
+        }, fw, indent=4)
+
+
+def test_data_visuals(basedir, visualize_subfolder = 'temp_output'):
+    json_file = os.path.join(basedir, "annotations.json")
+    with open(json_file) as f:
+        obj = json.load(f)
+    class_names = list(obj['classes']['mapping'].keys())
+
+    #! This is for the draw_annotation function to know our classes
+    cfg.DATA.CLASS_NAMES = class_names 
+    
+    roidbs = SimpsonDemo(basedir, "train").training_roidbs()
+
+    visualization_folder = os.path.join(basedir, visualize_subfolder)
+    if not os.path.isdir(visualization_folder): os.mkdir(visualization_folder)
+
+    visual_percentage = 0.01
+
+    for idx, r in enumerate(roidbs):
+        im = cv2.imread(r["file_name"])
+        
+        vis = draw_annotation(im, r["boxes"], r["class"])
+
+        if np.random.randint(0, 100) < (visual_percentage * 100):
+            visual_name = f'{idx}.png'
+            img = Image.fromarray(vis, 'RGB')
+            output_path = os.path.join(visualization_folder, visual_name)
+            img.save(output_path)
+            print('File: ', r['file_name'], ' visualized as: ', visual_name)
+
+    print('Example data visualizations are in ', visualization_folder)
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        '--basedir', help='Dataset directory',
+        type=str, required=False, default=BASE_DIR
+    )
+    parser.add_argument(
+        '--class-limit', help='maximum number of classes to parse and later use in training/prediction',
+        type=int, required=False, default=CLASS_LIMIT
+    )
+    parser.add_argument(
+        '--validation-size', help='size of the dataset to use for validation (0 < x < 1)',
+        type=float, required=False, default=VALIDATION_SIZE
+    )
+    parser.add_argument(
+        '--visualize', help='If used, small part of the training dataset will be visualized in a subfolder inside the dataset base directory',
+        action='store_true'
+    )
+    args = parser.parse_args()
+    
+    # Main part
+    process_annotations(args.basedir, args.class_limit, args.validation_size)
+
+    if args.visualize:
+        test_data_visuals(args.basedir)

--- a/dataset/parse_simpson.py
+++ b/dataset/parse_simpson.py
@@ -6,7 +6,7 @@ from PIL import Image
 import cv2
 import os
 from config import config as cfg
-from .simpson import SimpsonDemo
+from .simpson import SimpsonDemo, IMAGE_SUBFOLDER
 import json 
 import numpy as np
 
@@ -14,7 +14,6 @@ import numpy as np
 CLASS_LIMIT = 99 # simpson dataset have 18 classes
 VALIDATION_SIZE = 0.5 # minium validation size for 19 classed to be validly trained
 BASE_DIR = './data/simpson'
-IMAGE_SUBFOLDER = 'simpsons_dataset'
 
 
 def split_train_val(all_imgs, classes_count, validation_size):
@@ -122,7 +121,7 @@ def process_annotations(
         }, fw, indent=4)
 
 
-def test_data_visuals(basedir, visualize_subfolder = 'temp_output', image_subfolder=IMAGE_SUBFOLDER):
+def test_data_visuals(basedir, visualize_subfolder = 'temp_output'):
     json_file = os.path.join(basedir, "annotations.json")
     with open(json_file) as f:
         obj = json.load(f)
@@ -131,7 +130,7 @@ def test_data_visuals(basedir, visualize_subfolder = 'temp_output', image_subfol
     #! This is for the draw_annotation function to know our classes
     cfg.DATA.CLASS_NAMES = class_names 
     
-    roidbs = SimpsonDemo(basedir, "train", image_subfolder).training_roidbs()
+    roidbs = SimpsonDemo(basedir, "train").training_roidbs()
 
     visualization_folder = os.path.join(basedir, visualize_subfolder)
     if not os.path.isdir(visualization_folder): os.mkdir(visualization_folder)

--- a/dataset/simpson.py
+++ b/dataset/simpson.py
@@ -9,7 +9,7 @@ from config import config as cfg # TODO: remove later
 
 # Stolen link: https://github.com/duckrabbits/ObjectDetection/blob/master/model/parser.py
 
-CLASS_LIMIT = 2
+CLASS_LIMIT = 99
 
 class SimpsonDemo(DatasetSplit):
     def __init__(self, base_dir, split, image_subfolder = 'simpsons_dataset'):
@@ -39,7 +39,7 @@ class SimpsonDemo(DatasetSplit):
 
 
 
-def process_annotations(basedir, image_subfolder = 'simpsons_dataset', validation_size = 0.99):
+def process_annotations(basedir, image_subfolder = 'simpsons_dataset', validation_size = 0.95):
     # write the final annotation to two separate files
     annotation_file = os.path.join(basedir, "annotation.txt")
     classes_count = {}
@@ -96,6 +96,8 @@ def process_annotations(basedir, image_subfolder = 'simpsons_dataset', validatio
                 else:
                     all_imgs[filename]['imageset'] = 'val'
 
+        # NOTE: there's a chance that some class is empty in training dataset
+        # TODO: make sure all classes are in training dataset
         train_meta = []
         val_meta = []
         for key in all_imgs:

--- a/dataset/simpson.py
+++ b/dataset/simpson.py
@@ -120,8 +120,8 @@ def split_train_val(all_imgs, classes_count, validation_size):
 '''
 def process_annotations(
         basedir, 
-        validation_size,
         class_limit,
+        validation_size,
         image_subfolder=IMAGE_SUBFOLDER
     ):
     print(f'Number of training classes limit: {class_limit}')   

--- a/dataset/simpson.py
+++ b/dataset/simpson.py
@@ -30,6 +30,7 @@ class SimpsonDemo(DatasetSplit):
             'file_name': val['file_name'],
             'boxes' : np.asarray(val['boxes'], dtype=np.float32),
             'class' : np.asarray(val['class'], dtype=np.int32),
+            'is_crowd': np.asarray( [0], dtype=np.int8),
         }, obj)
         
         return list(formated)

--- a/dataset/simpson.py
+++ b/dataset/simpson.py
@@ -10,7 +10,7 @@ from config import config as cfg # TODO: remove later
 
 # Stolen link: https://github.com/duckrabbits/ObjectDetection/blob/master/model/parser.py
 
-CLASS_LIMIT = 5
+CLASS_LIMIT = 10
 
 class SimpsonDemo(DatasetSplit):
     def __init__(self, base_dir, split, image_subfolder = 'simpsons_dataset'):
@@ -40,7 +40,7 @@ class SimpsonDemo(DatasetSplit):
 
 
 
-def process_annotations(basedir, image_subfolder = 'simpsons_dataset', validation_size = 0.95):
+def process_annotations(basedir, image_subfolder = 'simpsons_dataset', validation_size = 0.7):
     # write the final annotation to two separate files
     annotation_file = os.path.join(basedir, "annotation.txt")
     classes_count = {}

--- a/dataset/simpson.py
+++ b/dataset/simpson.py
@@ -89,6 +89,7 @@ def process_annotations(basedir, image_subfolder = 'simpsons_dataset', validatio
             else:
                 val_meta.append(all_imgs[key])
 
+        # TODO: BG is class 1 or 0 (recheck!!!)
         classes_count['BG'] = 0
         class_mapping['BG'] = len(class_mapping) + 1
         print('Training images per class ({} classes) :'.format(len(classes_count)))
@@ -116,7 +117,7 @@ def register_simpson(basedir):
         DatasetRegistry.register(name, lambda x=split: SimpsonDemo(basedir, x))
         DatasetRegistry.register_metadata(name, "class_names", class_names)
 
-
+# TODO: data class is wrong order, need to be fixed
 def test_data_visuals():
     basedir = './data/simpson'
 
@@ -145,10 +146,11 @@ def test_data_visuals():
         vis = draw_annotation(im, r["boxes"], r["class"])
 
         if np.random.randint(0, 100) < (visual_percentage * 100):
-            print('File visualized: ', r['file_name'])
+            visual_name = f'{idx}.png'
             img = Image.fromarray(vis, 'RGB')
-            output_path = os.path.join(visualization_folder, f'{idx}.png')
+            output_path = os.path.join(visualization_folder, visual_name)
             img.save(output_path)
+            print('File: ', r['file_name'], ' visualized as: ', visual_name)
 
     print('Example data visualizations are in ', visualization_folder)
 

--- a/dataset/simpson.py
+++ b/dataset/simpson.py
@@ -40,7 +40,7 @@ class SimpsonDemo(DatasetSplit):
 
 
 
-def process_annotations(basedir, image_subfolder = 'simpsons_dataset', validation_size = 0.95):
+def process_annotations(basedir, image_subfolder = 'simpsons_dataset', validation_size = 0.98):
     # write the final annotation to two separate files
     annotation_file = os.path.join(basedir, "annotation.txt")
     classes_count = {}

--- a/dataset/simpson.py
+++ b/dataset/simpson.py
@@ -255,7 +255,6 @@ if __name__ == '__main__':
         '--visualize', help='If used, small part of the training dataset will be visualized in a subfolder inside the dataset base directory',
         action='store_true'
     )
-    parser.add_argument()
     args = parser.parse_args()
     
     # Main part

--- a/dataset/simpson.py
+++ b/dataset/simpson.py
@@ -5,6 +5,10 @@ import json
 from dataset import DatasetSplit, DatasetRegistry
 import random
 import argparse
+from viz import draw_annotation
+from config import config as cfg
+from PIL import Image
+import cv2
 
 '''
     Included an example.simpson.ipynb for reference (ran on colab)
@@ -201,12 +205,6 @@ def register_simpson(basedir):
         print('----')
 
 def test_data_visuals(basedir, visualize_subfolder = 'temp_output'):
-    from PIL import Image
-    from viz import draw_annotation
-    import cv2
-    from config import config as cfg
-
-
     json_file = os.path.join(basedir, "annotations.json")
     with open(json_file) as f:
         obj = json.load(f)

--- a/dataset/simpson.py
+++ b/dataset/simpson.py
@@ -32,7 +32,9 @@ class SimpsonDemo(DatasetSplit):
             'is_crowd': np.asarray( [0], dtype=np.int8),
         }, obj)
         
-        return list(formated)
+        result = list(formated)
+        print('Example roidb: ', result[0])
+        return result
 
 
 

--- a/dataset/simpson.py
+++ b/dataset/simpson.py
@@ -48,10 +48,12 @@ def process_annotations(basedir, image_subfolder = 'simpsons_dataset', validatio
         for line in f:
             line_split = line.strip().split(',')
             (filename,x1,y1,x2,y2,class_name) = line_split
+            x1, y1, x2, y2 = [int(x) for x in [x1, y1, x2, y2]]
 
             # !MAKE SURE BOUNDING BOX IS VALID
-            if x1 == x2 or y1 == y2: continue
-
+            area = (x2 - x1 + 1) * (y2 - y1 + 1)
+            if area <= 0: continue
+            
             # Remove leading '/character' in filename
             filename = os.path.join(basedir, image_subfolder + filename[12:])
             # update class count
@@ -67,9 +69,7 @@ def process_annotations(basedir, image_subfolder = 'simpsons_dataset', validatio
             if filename not in all_imgs:
                 all_imgs[filename] = {}
                 all_imgs[filename]['file_name'] = filename
-                all_imgs[filename]['boxes'] = [[
-                    int(val) for val in [x1,y1, x2, y2]
-                ]]
+                all_imgs[filename]['boxes'] = [[x1,y1, x2, y2]]
                 all_imgs[filename]['class'] = [class_mapping[class_name]]
 
                 # determine train or validation set 

--- a/dataset/simpson.py
+++ b/dataset/simpson.py
@@ -56,12 +56,12 @@ def process_annotations(basedir, image_subfolder = 'simpsons_dataset', validatio
         for line in f:
             line_split = line.strip().split(',')
             (filename,x1,y1,x2,y2,class_name) = line_split
-            x1, y1, x2, y2 = [int(x) for x in [x1, y1, x2, y2]]
+            x1, y1, x2, y2 = [int(x) + 0.5 for x in [x1, y1, x2, y2]]
 
             x1, x2 = min(x1,x2), max(x1,x2)
             y1, y2 = min(y1,y2), max(y1,y2)
             # !MAKE SURE BOUNDING BOX IS VALID
-            area = (x2 - x1 + 0.5) * (y2 - y1 + 0.5)
+            area = (x2 - x1) * (y2 - y1)
 
             if area <= 0: continue
             

--- a/dataset/simpson.py
+++ b/dataset/simpson.py
@@ -98,9 +98,10 @@ def process_annotations(basedir, image_subfolder = 'simpsons_dataset', validatio
         training_counter = {key : train_threshold for key in classes_count.keys()}
         train_meta = []
         val_meta = []
-        random.shuffle(all_imgs)
-
-        for key in all_imgs:
+        
+        image_keys = all_imgs.keys()
+        random.shuffle(image_keys)
+        for key in image_keys:
             classname = all_imgs[key]['classname'][0]
             if training_counter[classname] >= 0:
                 train_meta.append(all_imgs[key])

--- a/dataset/simpson.py
+++ b/dataset/simpson.py
@@ -137,7 +137,7 @@ def test_data_visuals():
     visualization_folder = os.path.join(basedir, 'temp_output')
     if not os.path.isdir(visualization_folder): os.mkdir(visualization_folder)
 
-    visual_percentage = 0.1
+    visual_percentage = 0.01
 
     for idx, r in enumerate(roidbs):
         im = cv2.imread(r["file_name"])

--- a/dataset/simpson.py
+++ b/dataset/simpson.py
@@ -10,7 +10,8 @@ from config import config as cfg # TODO: remove later
 
 # Stolen link: https://github.com/duckrabbits/ObjectDetection/blob/master/model/parser.py
 
-CLASS_LIMIT = 10
+# CLASS_LIMIT = 10
+CLASS_LIMIT = 99
 
 class SimpsonDemo(DatasetSplit):
     def __init__(self, base_dir, split, image_subfolder = 'simpsons_dataset'):
@@ -40,7 +41,8 @@ class SimpsonDemo(DatasetSplit):
 
 
 
-def process_annotations(basedir, image_subfolder = 'simpsons_dataset', validation_size = 0.7):
+# def process_annotations(basedir, image_subfolder = 'simpsons_dataset', validation_size = 0.7):
+def process_annotations(basedir, image_subfolder = 'simpsons_dataset', validation_size = 0.2):
     # write the final annotation to two separate files
     annotation_file = os.path.join(basedir, "annotation.txt")
     classes_count = {}

--- a/dataset/simpson.py
+++ b/dataset/simpson.py
@@ -10,7 +10,7 @@ from config import config as cfg # TODO: remove later
 
 # Stolen link: https://github.com/duckrabbits/ObjectDetection/blob/master/model/parser.py
 
-CLASS_LIMIT = 99
+CLASS_LIMIT = 5
 
 class SimpsonDemo(DatasetSplit):
     def __init__(self, base_dir, split, image_subfolder = 'simpsons_dataset'):
@@ -40,7 +40,7 @@ class SimpsonDemo(DatasetSplit):
 
 
 
-def process_annotations(basedir, image_subfolder = 'simpsons_dataset', validation_size = 0.98):
+def process_annotations(basedir, image_subfolder = 'simpsons_dataset', validation_size = 0.95):
     # write the final annotation to two separate files
     annotation_file = os.path.join(basedir, "annotation.txt")
     classes_count = {}

--- a/dataset/simpson.py
+++ b/dataset/simpson.py
@@ -54,8 +54,10 @@ def process_annotations(basedir, image_subfolder = 'simpsons_dataset', validatio
             area = (x2 - x1 + 1) * (y2 - y1 + 1)
             if area <= 0: continue
             
-            # Remove leading '/character' in filename
-            filename = os.path.join(basedir, image_subfolder + filename[12:])
+            #! Remove leading '/character' or '/character2' in filename
+            filename = '/'.join(filename.split('/')[2:])
+            filename = os.path.join(basedir, image_subfolder, filename) 
+
             # update class count
             if class_name not in classes_count:
                 classes_count[class_name] = 1
@@ -135,14 +137,17 @@ def test_data_visuals():
     visualization_folder = os.path.join(basedir, 'temp_output')
     if not os.path.isdir(visualization_folder): os.mkdir(visualization_folder)
 
+    visual_percentage = 0.1
+
     for idx, r in enumerate(roidbs):
-        print('File: ', r['file_name'])
         im = cv2.imread(r["file_name"])
         
         vis = draw_annotation(im, r["boxes"], r["class"])
-        img = Image.fromarray(vis, 'RGB')
-        output_path = os.path.join(visualization_folder, f'{idx}.png')
-        img.save(output_path)
+
+        if np.random.randint(0, 100) < (visual_percentage * 100):
+            img = Image.fromarray(vis, 'RGB')
+            output_path = os.path.join(visualization_folder, f'{idx}.png')
+            img.save(output_path)
 
     print('Example data visualizations are in ', visualization_folder)
 

--- a/dataset/simpson.py
+++ b/dataset/simpson.py
@@ -47,7 +47,8 @@ def process_annotations(basedir, image_subfolder = 'simpsons_dataset', validatio
     classes_count['BG'] = 0
     class_mapping['BG'] = 0
 
-
+    # {'file_name': './data/simpson/simpsons_dataset/abraham_grampa_simpson/pic_0000.jpg', 'boxes': array([[52., 72., 57., 72.]], dtype=float32), 'class': array([1], dtype=int32), 'is_crowd': array([0], dtype=int8)}
+    # {'file_name': './data/balloon/train/34020010494_e5cb88e1c4_k.jpg', 'boxes': array([[ 994.5,  619.5, 1445.5, 1166.5]], dtype=float32), 'class': array([1], dtype=int32), 'is_crowd': array([0], dtype=int8)}
     with open(annotation_file,'r') as f:
         print('Parsing annotation files')
         for line in f:
@@ -58,7 +59,7 @@ def process_annotations(basedir, image_subfolder = 'simpsons_dataset', validatio
             x1, x2 = min(x1,x2), max(x1,x2)
             y1, y2 = min(y1,y2), max(y1,y2)
             # !MAKE SURE BOUNDING BOX IS VALID
-            area = (x2 - x1 + 1) * (y2 - y1 + 1)
+            area = (x2 - x1 + 0.5) * (y2 - y1 + 0.5)
 
             if area <= 0: continue
             

--- a/dataset/simpson.py
+++ b/dataset/simpson.py
@@ -1,0 +1,109 @@
+import os
+import numpy as np
+import json
+from dataset import DatasetSplit, DatasetRegistry
+import pandas as pd
+import random
+from pprint import pprint
+# Stolen link: https://github.com/duckrabbits/ObjectDetection/blob/master/model/parser.py
+__all__ = ["register_simpson"]
+
+
+class SimpsonDemo(DatasetSplit):
+    def __init__(self, base_dir, split):
+        assert split in ["train", "val"]
+        base_dir = os.path.expanduser(base_dir)
+        self.imgdir = os.path.join(base_dir, split)
+        self.base_dir = base_dir
+        assert os.path.isdir(self.imgdir), self.imgdir
+
+
+    def training_roidbs(self):
+        # TODO: read annotation from the correct file
+        pass
+
+
+
+
+
+def process_annotations(basedir, image_subfolder = 'simpsons_dataset', validation_size = 0.2):
+    # write the final annotation to two separate files
+    annotation_file = os.path.join(basedir, "annotation.txt")
+    classes_count = {}
+    class_mapping = {}
+    all_imgs = {}
+
+    with open(annotation_file,'r') as f:
+        print('Parsing annotation files')
+        for line in f:
+            line_split = line.strip().split(',')
+            (filename,x1,y1,x2,y2,class_name) = line_split
+
+            # Remove leading '/character' in filename
+            filename = os.path.join(basedir, image_subfolder + filename[12:])
+            # TODO: file path is wrong, fix it.
+            # update class count
+            if class_name not in classes_count:
+                classes_count[class_name] = 1
+            else:
+                classes_count[class_name] += 1
+
+            if class_name not in class_mapping:
+                class_mapping[class_name] = len(class_mapping) + 1
+                # this means first class is 1, second is 2, ...
+
+            if filename not in all_imgs:
+                all_imgs[filename] = {}
+                all_imgs[filename]['file_name'] = filename
+                all_imgs[filename]['boxes'] = [[
+                    int(val) for val in [x1,y1, x2, y2]
+                ]]
+                all_imgs[filename]['class'] = [class_mapping[class_name]]
+
+                # determine train or validation set 
+                validation_threshold = int(validation_size * 100)
+                if np.random.randint(0, 100) > validation_threshold:
+                    all_imgs[filename]['imageset'] = 'train'
+                else:
+                    all_imgs[filename]['imageset'] = 'val'
+
+        train_meta = []
+        val_meta = []
+        for key in all_imgs:
+            if all_imgs[key]['imageset'] == 'train':
+                train_meta.append(all_imgs[key])
+            else:
+                val_meta.append(all_imgs[key])
+
+        classes_count['bg'] = 0
+        class_mapping['bg'] = len(class_mapping) + 1
+        print('Training images per class ({} classes) :'.format(len(classes_count)))
+        pprint.pprint(classes_count)
+
+    # write to files
+    with open(os.path.join(basedir, 'annotations.json'), 'w') as fw:
+        json.dump({
+            'train': train_meta, 
+            'val': val_meta,
+            'classes' : {
+                'count' : classes_count,
+                'mapping' : class_mapping
+            }
+        }, fw)
+
+def register_simpson(basedir):
+    pass
+
+if __name__ == '__main__':
+    basedir = './data/simpson'
+    process_annotations(basedir)
+    # roidbs = SimpsonDemo(basedir, "train").training_roidbs()
+    # print("#images:", len(roidbs))
+
+    # from viz import draw_annotation
+    # from tensorpack.utils.viz import interactive_imshow as imshow
+    # import cv2
+    # for r in roidbs:
+    #     im = cv2.imread(r["file_name"])
+    #     vis = draw_annotation(im, r["boxes"], r["class"], r["segmentation"])
+    #     imshow(vis)

--- a/dataset/simpson.py
+++ b/dataset/simpson.py
@@ -43,6 +43,10 @@ def process_annotations(basedir, image_subfolder = 'simpsons_dataset', validatio
     class_mapping = {}
     all_imgs = {}
 
+    classes_count['BG'] = 0
+    class_mapping['BG'] = 0
+
+
     with open(annotation_file,'r') as f:
         print('Parsing annotation files')
         for line in f:
@@ -65,7 +69,7 @@ def process_annotations(basedir, image_subfolder = 'simpsons_dataset', validatio
                 classes_count[class_name] += 1
 
             if class_name not in class_mapping:
-                class_mapping[class_name] = len(class_mapping) + 1
+                class_mapping[class_name] = len(class_mapping)
                 # this means first class is 1, second is 2, ...
 
             if filename not in all_imgs:
@@ -89,9 +93,6 @@ def process_annotations(basedir, image_subfolder = 'simpsons_dataset', validatio
             else:
                 val_meta.append(all_imgs[key])
 
-        # TODO: BG is class 1 or 0 (recheck!!!)
-        classes_count['BG'] = 0
-        class_mapping['BG'] = len(class_mapping) + 1
         print('Training images per class ({} classes) :'.format(len(classes_count)))
         pprint.pprint(classes_count)
 
@@ -117,7 +118,6 @@ def register_simpson(basedir):
         DatasetRegistry.register(name, lambda x=split: SimpsonDemo(basedir, x))
         DatasetRegistry.register_metadata(name, "class_names", class_names)
 
-# TODO: data class is wrong order, need to be fixed
 def test_data_visuals():
     basedir = './data/simpson'
 

--- a/dataset/simpson.py
+++ b/dataset/simpson.py
@@ -5,6 +5,7 @@ from dataset import DatasetSplit, DatasetRegistry
 import pandas as pd
 import random
 import pprint
+from config import config as cfg # TODO: remove later
 
 # Stolen link: https://github.com/duckrabbits/ObjectDetection/blob/master/model/parser.py
 __all__ = ["register_simpson"]
@@ -109,14 +110,17 @@ def register_simpson(basedir):
 
 if __name__ == '__main__':
     basedir = './data/simpson'
-    process_annotations(basedir)
+    # process_annotations(basedir)
+    cfg.DATA.CLASS_NAMES = ['BG', 'abraham_grampa_simpson', 'apu_nahasapeemapetilon', 'bart_simpson', 'charles_montgomery_burns', 'chief_wiggum', 'comic_book_guy', 'edna_krabappel', 'homer_simpson', 'kent_brockman', 'krusty_the_clown', 'lisa_simpson', 'marge_simpson', 'milhouse_van_houten', 'moe_szyslak', 'ned_flanders', 'nelson_muntz', 'principal_skinner', 'sideshow_bob']
     roidbs = SimpsonDemo(basedir, "train").training_roidbs()
     print("#images:", len(roidbs))
 
     from viz import draw_annotation
-    from tensorpack.utils.viz import interactive_imshow as imshow
+    # from tensorpack.utils.viz import interactive_imshow as imshow
+    from google.colab.patches import cv2_imshow
+
     import cv2
     for r in roidbs:
         im = cv2.imread(r["file_name"])
         vis = draw_annotation(im, r["boxes"], r["class"])
-        imshow(vis)
+        cv2_imshow(vis)

--- a/dataset/simpson.py
+++ b/dataset/simpson.py
@@ -3,29 +3,31 @@ import os
 import numpy as np
 import json
 from dataset import DatasetSplit, DatasetRegistry
-import pandas as pd
 import random
-import pprint
-from config import config as cfg # TODO: remove later
+import argparse
 
-# Stolen link: https://github.com/duckrabbits/ObjectDetection/blob/master/model/parser.py
+'''
+    Included an example.simpson.ipynb for reference (ran on colab)
+'''
 
-# CLASS_LIMIT = 10
-CLASS_LIMIT = 99
-VALIDATION_SIZE = 0.7
+# Default configs
+CLASS_LIMIT = 99 # simpson dataset have 18 classes
+VALIDATION_SIZE = 0.5 # minium validation size for 19 classed to be validly trained
+BASE_DIR = './data/simpson'
+IMAGE_SUBFOLDER = 'simpsons_dataset'
 
 '''
     ! IMPORTANT TRAINING NOTE:
         FOLLOW THESE GUIDELINES IF YOU LIKE THE MODEL TO MAKE ANY PROPER PREDICTIONS AT ALL.
         -- these are from my own experiment with the model and simpson dataset (very large with lots of classes) --
     1. Data size is very important: the more classes are trained, the MORE DATA NEEDED
-        Successful train on:
+        Successfully train on: (meaning at least needs)
         - 2 classes -> 0.02 train size
         - 5 classes -> 0.05 train size
         - 10 classes -> 0.2 train size
-        - 18 (all) classes -> 0.8 train size
+        - 18 (all) classes -> 0.5 train size
     2. Training should at least pass through the whole training set ONCE.
-        So pay attention to `TRAIN.LR_SCHEDULE`
+        So pay attention to `TRAIN.LR_SCHEDULE` and tweak accordingly
         And try to make sure that (in the logged output) -> "Total passes of the training set is:" >= 1
     3. If your training metrics starts to show results as NAN -> Likely failed and will give no predictions
         Ex: total_cost: 0.34688
@@ -34,10 +36,14 @@ VALIDATION_SIZE = 0.7
     4. Epoch size `TRAIN.STEPS_PER_EPOCH` is not that important
         But model saving and other callbacks will be called periodically based on epoch, 
         so smaller value means more checkpoint saving and takes more time
-    
+    5. Conclusion:
+        - Have enough data
+        - Raise TRAIN.LR_SCHEDULE to pass though the training set at least once
+        - Train with proper TRAIN.STEPS_PER_EPOCH and see results
 '''
+
 class SimpsonDemo(DatasetSplit):
-    def __init__(self, base_dir, split, image_subfolder = 'simpsons_dataset'):
+    def __init__(self, base_dir, split, image_subfolder=IMAGE_SUBFOLDER):
         assert split in ["train", "val"]
         base_dir = os.path.expanduser(base_dir)
         self.imgdir = os.path.join(base_dir, image_subfolder)
@@ -45,7 +51,9 @@ class SimpsonDemo(DatasetSplit):
         self.split = split
         assert os.path.isdir(self.imgdir), self.imgdir
 
-
+    '''
+        training_roidbs just reads from annotation.json and parse to correct format
+    '''
     def training_roidbs(self):
         json_file = os.path.join(self.base_dir, "annotations.json")
         with open(json_file) as f:
@@ -59,29 +67,75 @@ class SimpsonDemo(DatasetSplit):
         }, obj)
         
         result = list(formated)
+
         print('Example roidb: ', result[0])
-        # {'file_name': './data/balloon/train/34020010494_e5cb88e1c4_k.jpg', 'boxes': array([[ 994.5,  619.5, 1445.5, 1166.5]], dtype=float32), 'class': array([1], dtype=int32), 'is_crowd': array([0], dtype=int8)}
+        ''' Should be:
+            {
+                'file_name': './data/balloon/train/34020010494_e5cb88e1c4_k.jpg', 
+                'boxes': array([[ 994.5,  619.5, 1445.5, 1166.5]], dtype=float32), 
+                'class': array([1], dtype=int32), 
+                'is_crowd': array([0], dtype=int8)
+            }
+        '''
         return result
 
 
 
-def process_annotations(basedir, image_subfolder = 'simpsons_dataset', validation_size = VALIDATION_SIZE):
-    print('---- Annotation Processing Params ----')
-    print(f'Number of training classes limit: {CLASS_LIMIT}')   
+def split_train_val(all_imgs, classes_count, validation_size):
+    '''
+        This function will try balance of classes
+        1. train size is based on the count of the smallest class (class with least samples)
+            Meaning if train_size is 0.1 and smallest class have 10 samples then
+            -> We take 1 sample from each class of the training set
+        2. This ensure a kind-of-balance and uniform distribution
+        3. And also no empty training class samples
+    '''
+    min_size,  _ = max(zip(classes_count.values(), classes_count.keys()))
+    train_threshold = math.ceil((1 - validation_size) * min_size)
+    training_counter = {key : train_threshold for key in classes_count.keys()}
+    train = []
+    val = []
+    
+    image_keys = list(all_imgs.keys())
+    random.shuffle(image_keys)
+    for key in image_keys:
+        classname = all_imgs[key]['classname'][0]
+        if training_counter[classname] >= 0:
+            train.append(all_imgs[key])
+            training_counter[classname] -= 1
+        else:
+            val.append(all_imgs[key])
+
+    print(f'Classes count: {len(classes_count)}')
+    print(f'Train size: {len(train)}, validation size: {len(val)}')
+    return train, val
+
+'''
+    Parse annotation.txt and write to annotation.json with train/val split for easy
+        training without actually splitting the dataset into train/val folder
+
+    NOTE: process_annotations's
+        bounding box parsing is based on code from the following project
+    https://github.com/duckrabbits/ObjectDetection/blob/master/model/parser.py
+'''
+def process_annotations(
+        basedir, 
+        validation_size,
+        class_limit,
+        image_subfolder=IMAGE_SUBFOLDER
+    ):
+    print(f'Number of training classes limit: {class_limit}')   
     print(f'Training size: {1 - validation_size}')
     
-    # write the final annotation to two separate files
     annotation_file = os.path.join(basedir, "annotation.txt")
     classes_count = {}
     class_mapping = {}
     all_imgs = {}
 
-    # NOTE: if you want to remove this, then you must also change how classes are added to frame work
     classes_count['BG'] = 0
     class_mapping['BG'] = 0
 
     with open(annotation_file,'r') as f:
-        print('Parsing annotation files')
         for line in f:
             line_split = line.strip().split(',')
             (filename,x1,y1,x2,y2,class_name) = line_split
@@ -89,7 +143,7 @@ def process_annotations(basedir, image_subfolder = 'simpsons_dataset', validatio
 
             x1, x2 = min(x1,x2), max(x1,x2)
             y1, y2 = min(y1,y2), max(y1,y2)
-            # !MAKE SURE BOUNDING BOX IS VALID
+            #! MAKE SURE BOUNDING BOX IS VALID
             area = (x2 - x1) * (y2 - y1)
 
             if area <= 0: continue
@@ -101,7 +155,7 @@ def process_annotations(basedir, image_subfolder = 'simpsons_dataset', validatio
 
 
             if class_name not in class_mapping:
-                if len(class_mapping) > CLASS_LIMIT: continue
+                if len(class_mapping) > class_limit: continue
                 class_mapping[class_name] = len(class_mapping)
                 # this means first class is 1, second is 2, ...
             
@@ -118,30 +172,9 @@ def process_annotations(basedir, image_subfolder = 'simpsons_dataset', validatio
                 all_imgs[filename]['class'] = [class_mapping[class_name]]
                 all_imgs[filename]['classname'] = [class_name]
 
+        train_meta, val_meta = split_train_val(all_imgs, classes_count, validation_size)
 
-        # NOTE: Train size will try to have balance of classes and also no class is missing from training set
-        min_size,  _ = max(zip(classes_count.values(), classes_count.keys()))
-        train_threshold = math.ceil((1 - validation_size) * min_size)
-        training_counter = {key : train_threshold for key in classes_count.keys()}
-        train_meta = []
-        val_meta = []
-        
-        image_keys = list(all_imgs.keys())
-        random.shuffle(image_keys)
-        for key in image_keys:
-            classname = all_imgs[key]['classname'][0]
-            if training_counter[classname] >= 0:
-                train_meta.append(all_imgs[key])
-                training_counter[classname] -= 1
-            else:
-                val_meta.append(all_imgs[key])
-
-        print('Training images per class ({} classes) :'.format(len(classes_count)))
-        pprint.pprint(classes_count)
-        print(f'Train size: {len(train_meta)}, validation size: {len(val_meta)}')
-        print('--------------------------------------')
-
-    # write to files
+    # write to file
     with open(os.path.join(basedir, 'annotations.json'), 'w') as fw:
         json.dump({
             'classes' : {
@@ -152,37 +185,39 @@ def process_annotations(basedir, image_subfolder = 'simpsons_dataset', validatio
             'val': val_meta,
         }, fw, indent=4)
 
-def register_simpson(basedir, process_raw_annotations=True):
-    # TODO: fix major bug cause if you process annotations here then you cant register other data sets to train them!!!!
-    if basedir.split('/')[-1] != 'simpson': return
-    if process_raw_annotations: process_annotations(basedir) 
-    json_file = os.path.join(basedir, "annotations.json")
-    with open(json_file) as f:
-        obj = json.load(f)
-    class_names = list(obj['classes']['mapping'].keys())
-    for split in ['train', 'val']:
-        name = "simpson_" + split
-        DatasetRegistry.register(name, lambda x=split: SimpsonDemo(basedir, x))
-        DatasetRegistry.register_metadata(name, "class_names", class_names)
+def register_simpson(basedir):
+    try:
+        json_file = os.path.join(basedir, "annotations.json")
+        with open(json_file) as f:
+            obj = json.load(f)
+        class_names = list(obj['classes']['mapping'].keys())
+        for split in ['train', 'val']:
+            name = "simpson_" + split
+            DatasetRegistry.register(name, lambda x=split: SimpsonDemo(basedir, x))
+            DatasetRegistry.register_metadata(name, "class_names", class_names)
+    except Exception as e:
+        print('WRN: If your not training/testing on simpson dataset, ignore this error!')
+        print(e)
+        print('----')
 
-def test_data_visuals():
-    basedir = './data/simpson'
-
-    process_annotations(basedir)
-    json_file = os.path.join(basedir, "annotations.json")
-    with open(json_file) as f:
-        obj = json.load(f)
-    class_names = list(obj['classes']['mapping'].keys())
-    cfg.DATA.CLASS_NAMES = class_names
-    
-    roidbs = SimpsonDemo(basedir, "train").training_roidbs()
-    print("#images:", len(roidbs))
-
+def test_data_visuals(basedir, visualize_subfolder = 'temp_output'):
     from PIL import Image
     from viz import draw_annotation
     import cv2
+    from config import config as cfg
 
-    visualization_folder = os.path.join(basedir, 'temp_output')
+
+    json_file = os.path.join(basedir, "annotations.json")
+    with open(json_file) as f:
+        obj = json.load(f)
+    class_names = list(obj['classes']['mapping'].keys())
+
+    #! This is for the draw_annotation function to know our classes
+    cfg.DATA.CLASS_NAMES = class_names 
+    
+    roidbs = SimpsonDemo(basedir, "train").training_roidbs()
+
+    visualization_folder = os.path.join(basedir, visualize_subfolder)
     if not os.path.isdir(visualization_folder): os.mkdir(visualization_folder)
 
     visual_percentage = 0.01
@@ -203,4 +238,28 @@ def test_data_visuals():
 
 
 if __name__ == '__main__':
-    test_data_visuals()
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        '--basedir', help='Dataset directory',
+        type=str, required=False, default=BASE_DIR
+    )
+    parser.add_argument(
+        '--class-limit', help='maximum number of classes to parse and later use in training/prediction',
+        type=int, required=False, default=CLASS_LIMIT
+    )
+    parser.add_argument(
+        '--validation-size', help='size of the dataset to use for validation (0 < x < 1)',
+        type=float, required=False, default=VALIDATION_SIZE
+    )
+    parser.add_argument(
+        '--visualize', help='If used, small part of the training dataset will be visualized in a subfolder inside the dataset base directory',
+        action='store_true'
+    )
+    parser.add_argument()
+    args = parser.parse_args()
+    
+    # Main part
+    process_annotations(args.basedir, args.class_limit, args.validation_size)
+
+    if args.visualize:
+        test_data_visuals(args.basedir)

--- a/dataset/simpson.py
+++ b/dataset/simpson.py
@@ -145,6 +145,7 @@ def test_data_visuals():
         vis = draw_annotation(im, r["boxes"], r["class"])
 
         if np.random.randint(0, 100) < (visual_percentage * 100):
+            print('File visualized: ', r['file_name'])
             img = Image.fromarray(vis, 'RGB')
             output_path = os.path.join(visualization_folder, f'{idx}.png')
             img.save(output_path)

--- a/dataset/simpson.py
+++ b/dataset/simpson.py
@@ -2,7 +2,6 @@ import os
 import numpy as np
 import json
 from dataset import DatasetSplit, DatasetRegistry
-from parse_simpson import IMAGE_SUBFOLDER
 
 '''
     Included an example.simpson.ipynb for reference (ran on colab)
@@ -36,7 +35,7 @@ from parse_simpson import IMAGE_SUBFOLDER
 '''
 
 class SimpsonDemo(DatasetSplit):
-    def __init__(self, base_dir, split, image_subfolder=IMAGE_SUBFOLDER):
+    def __init__(self, base_dir, split, image_subfolder):
         assert split in ["train", "val"]
         base_dir = os.path.expanduser(base_dir)
         self.imgdir = os.path.join(base_dir, image_subfolder)

--- a/dataset/simpson.py
+++ b/dataset/simpson.py
@@ -24,9 +24,15 @@ class SimpsonDemo(DatasetSplit):
     def training_roidbs(self):
         json_file = os.path.join(self.base_dir, "annotations.json")
         with open(json_file) as f:
-            obj = json.load(f)
-
-        return obj[self.split]
+            obj = json.load(f)[self.split]
+        
+        formated = map(lambda _, val: {
+            'file_name': val['file_name'],
+            'boxes' : np.asarray(val['boxes'], dtype=np.float32),
+            'class' : np.asarray(val['class'], dtype=np.int32),
+        }, obj)
+        
+        return list(formated)
 
 
 
@@ -122,5 +128,6 @@ if __name__ == '__main__':
     import cv2
     for r in roidbs:
         im = cv2.imread(r["file_name"])
+        
         vis = draw_annotation(im, r["boxes"], r["class"])
         cv2_imshow(vis)

--- a/dataset/simpson.py
+++ b/dataset/simpson.py
@@ -42,46 +42,8 @@ IMAGE_SUBFOLDER = 'simpsons_dataset'
         - Train with proper TRAIN.STEPS_PER_EPOCH and see results
 '''
 
-class SimpsonDemo(DatasetSplit):
-    def __init__(self, base_dir, split, image_subfolder=IMAGE_SUBFOLDER):
-        assert split in ["train", "val"]
-        base_dir = os.path.expanduser(base_dir)
-        self.imgdir = os.path.join(base_dir, image_subfolder)
-        self.base_dir = base_dir
-        self.split = split
-        assert os.path.isdir(self.imgdir), self.imgdir
-
-    '''
-        training_roidbs just reads from annotation.json and parse to correct format
-    '''
-    def training_roidbs(self):
-        json_file = os.path.join(self.base_dir, "annotations.json")
-        with open(json_file) as f:
-            obj = json.load(f)[self.split]
-        
-        formated = map(lambda val: {
-            'file_name': val['file_name'],
-            'boxes' : np.asarray(val['boxes'], dtype=np.float32),
-            'class' : np.asarray(val['class'], dtype=np.int32),
-            'is_crowd': np.asarray( [0], dtype=np.int8),
-        }, obj)
-        
-        result = list(formated)
-
-        print('Example roidb: ', result[0])
-        ''' Should be:
-            {
-                'file_name': './data/balloon/train/34020010494_e5cb88e1c4_k.jpg', 
-                'boxes': array([[ 994.5,  619.5, 1445.5, 1166.5]], dtype=float32), 
-                'class': array([1], dtype=int32), 
-                'is_crowd': array([0], dtype=int8)
-            }
-        '''
-        return result
-
-
-
-def split_train_val(all_imgs, classes_count, validation_size):
+# ------ PRIVATE METHODS
+def _split_train_val(all_imgs, classes_count, validation_size):
     '''
         This function will try balance of classes
         1. train size is based on the count of the smallest class (class with least samples)
@@ -118,7 +80,7 @@ def split_train_val(all_imgs, classes_count, validation_size):
         bounding box parsing is based on code from the following project
     https://github.com/duckrabbits/ObjectDetection/blob/master/model/parser.py
 '''
-def process_annotations(
+def _process_annotations(
         basedir, 
         class_limit,
         validation_size,
@@ -172,7 +134,7 @@ def process_annotations(
                 all_imgs[filename]['class'] = [class_mapping[class_name]]
                 all_imgs[filename]['classname'] = [class_name]
 
-        train_meta, val_meta = split_train_val(all_imgs, classes_count, validation_size)
+        train_meta, val_meta = _split_train_val(all_imgs, classes_count, validation_size)
 
     # write to file
     with open(os.path.join(basedir, 'annotations.json'), 'w') as fw:
@@ -185,22 +147,8 @@ def process_annotations(
             'val': val_meta,
         }, fw, indent=4)
 
-def register_simpson(basedir):
-    try:
-        json_file = os.path.join(basedir, "annotations.json")
-        with open(json_file) as f:
-            obj = json.load(f)
-        class_names = list(obj['classes']['mapping'].keys())
-        for split in ['train', 'val']:
-            name = "simpson_" + split
-            DatasetRegistry.register(name, lambda x=split: SimpsonDemo(basedir, x))
-            DatasetRegistry.register_metadata(name, "class_names", class_names)
-    except Exception as e:
-        print('WRN: If your not training/testing on simpson dataset, ignore this error!')
-        print(e)
-        print('----')
 
-def test_data_visuals(basedir, visualize_subfolder = 'temp_output'):
+def _test_data_visuals(basedir, visualize_subfolder = 'temp_output'):
     from PIL import Image
     from viz import draw_annotation
     import cv2
@@ -237,6 +185,61 @@ def test_data_visuals(basedir, visualize_subfolder = 'temp_output'):
     print('Example data visualizations are in ', visualization_folder)
 
 
+
+# ------ PUBLIC METHODS
+class SimpsonDemo(DatasetSplit):
+    def __init__(self, base_dir, split, image_subfolder=IMAGE_SUBFOLDER):
+        assert split in ["train", "val"]
+        base_dir = os.path.expanduser(base_dir)
+        self.imgdir = os.path.join(base_dir, image_subfolder)
+        self.base_dir = base_dir
+        self.split = split
+        assert os.path.isdir(self.imgdir), self.imgdir
+
+    '''
+        training_roidbs just reads from annotation.json and parse to correct format
+    '''
+    def training_roidbs(self):
+        json_file = os.path.join(self.base_dir, "annotations.json")
+        with open(json_file) as f:
+            obj = json.load(f)[self.split]
+        
+        formated = map(lambda val: {
+            'file_name': val['file_name'],
+            'boxes' : np.asarray(val['boxes'], dtype=np.float32),
+            'class' : np.asarray(val['class'], dtype=np.int32),
+            'is_crowd': np.asarray( [0], dtype=np.int8),
+        }, obj)
+        
+        result = list(formated)
+
+        print('Example roidb: ', result[0])
+        ''' Should be:
+            {
+                'file_name': './data/balloon/train/34020010494_e5cb88e1c4_k.jpg', 
+                'boxes': array([[ 994.5,  619.5, 1445.5, 1166.5]], dtype=float32), 
+                'class': array([1], dtype=int32), 
+                'is_crowd': array([0], dtype=int8)
+            }
+        '''
+        return result
+
+def register_simpson(basedir):
+    try:
+        json_file = os.path.join(basedir, "annotations.json")
+        with open(json_file) as f:
+            obj = json.load(f)
+        class_names = list(obj['classes']['mapping'].keys())
+        for split in ['train', 'val']:
+            name = "simpson_" + split
+            DatasetRegistry.register(name, lambda x=split: SimpsonDemo(basedir, x))
+            DatasetRegistry.register_metadata(name, "class_names", class_names)
+    except Exception as e:
+        print('WRN: If your not training/testing on simpson dataset, ignore this error!')
+        print(e)
+        print('----')
+
+
 if __name__ == '__main__':
     parser = argparse.ArgumentParser()
     parser.add_argument(
@@ -258,7 +261,7 @@ if __name__ == '__main__':
     args = parser.parse_args()
     
     # Main part
-    process_annotations(args.basedir, args.class_limit, args.validation_size)
+    _process_annotations(args.basedir, args.class_limit, args.validation_size)
 
     if args.visualize:
-        test_data_visuals(args.basedir)
+        _test_data_visuals(args.basedir)

--- a/dataset/simpson.py
+++ b/dataset/simpson.py
@@ -66,6 +66,10 @@ class SimpsonDemo(DatasetSplit):
 
 # def process_annotations(basedir, image_subfolder = 'simpsons_dataset', validation_size = 0.7):
 def process_annotations(basedir, image_subfolder = 'simpsons_dataset', validation_size = 0.5):
+    print('---- Annotation Processing Params ----')
+    print(f'Number of training classes limit: {CLASS_LIMIT}')   
+    print(f'Training size: {1 - validation_size}')
+    
     # write the final annotation to two separate files
     annotation_file = os.path.join(basedir, "annotation.txt")
     classes_count = {}
@@ -135,6 +139,7 @@ def process_annotations(basedir, image_subfolder = 'simpsons_dataset', validatio
         print('Training images per class ({} classes) :'.format(len(classes_count)))
         pprint.pprint(classes_count)
         print(f'Train size: {len(train_meta)}, validation size: {len(val_meta)}')
+        print('--------------------------------------')
 
     # write to files
     with open(os.path.join(basedir, 'annotations.json'), 'w') as fw:

--- a/dataset/simpson.py
+++ b/dataset/simpson.py
@@ -8,7 +8,6 @@ import pprint
 from config import config as cfg # TODO: remove later
 
 # Stolen link: https://github.com/duckrabbits/ObjectDetection/blob/master/model/parser.py
-__all__ = ["register_simpson"]
 
 
 class SimpsonDemo(DatasetSplit):
@@ -44,8 +43,8 @@ def process_annotations(basedir, image_subfolder = 'simpsons_dataset', validatio
     class_mapping = {}
     all_imgs = {}
 
-    classes_count['BG'] = 0
-    class_mapping['BG'] = 0
+    # classes_count['BG'] = 0
+    # class_mapping['BG'] = 0
 
 
     with open(annotation_file,'r') as f:
@@ -55,8 +54,11 @@ def process_annotations(basedir, image_subfolder = 'simpsons_dataset', validatio
             (filename,x1,y1,x2,y2,class_name) = line_split
             x1, y1, x2, y2 = [int(x) for x in [x1, y1, x2, y2]]
 
+            x1, x2 = min(x1,x2), max(x1,x2)
+            y1, y2 = min(y1,y2), max(y1,y2)
             # !MAKE SURE BOUNDING BOX IS VALID
             area = (x2 - x1 + 1) * (y2 - y1 + 1)
+
             if area <= 0: continue
             
             #! Remove leading '/character' or '/character2' in filename
@@ -70,7 +72,7 @@ def process_annotations(basedir, image_subfolder = 'simpsons_dataset', validatio
                 classes_count[class_name] += 1
 
             if class_name not in class_mapping:
-                class_mapping[class_name] = len(class_mapping)
+                class_mapping[class_name] = len(class_mapping) + 1
                 # this means first class is 1, second is 2, ...
 
             if filename not in all_imgs:
@@ -109,7 +111,9 @@ def process_annotations(basedir, image_subfolder = 'simpsons_dataset', validatio
         }, fw, indent=4)
 
 def register_simpson(basedir):
-    process_annotations(basedir)
+    # TODO: fix major bug cause if you process annotations here then you cant register other data sets to train them!!!!
+    if basedir.split('/')[-1] != 'simpson': return
+    process_annotations(basedir) 
     json_file = os.path.join(basedir, "annotations.json")
     with open(json_file) as f:
         obj = json.load(f)

--- a/dataset/simpson.py
+++ b/dataset/simpson.py
@@ -26,7 +26,7 @@ class SimpsonDemo(DatasetSplit):
         with open(json_file) as f:
             obj = json.load(f)[self.split]
         
-        formated = map(lambda _, val: {
+        formated = map(lambda val: {
             'file_name': val['file_name'],
             'boxes' : np.asarray(val['boxes'], dtype=np.float32),
             'class' : np.asarray(val['class'], dtype=np.int32),
@@ -127,6 +127,8 @@ if __name__ == '__main__':
 
     import cv2
     for r in roidbs:
+        print('testing')
+        pprint.pprint(r)
         im = cv2.imread(r["file_name"])
         
         vis = draw_annotation(im, r["boxes"], r["class"])

--- a/dataset/simpson.py
+++ b/dataset/simpson.py
@@ -12,6 +12,7 @@ from config import config as cfg # TODO: remove later
 
 # CLASS_LIMIT = 10
 CLASS_LIMIT = 99
+VALIDATION_SIZE = 0.7
 
 '''
     ! IMPORTANT TRAINING NOTE:
@@ -64,8 +65,7 @@ class SimpsonDemo(DatasetSplit):
 
 
 
-# def process_annotations(basedir, image_subfolder = 'simpsons_dataset', validation_size = 0.7):
-def process_annotations(basedir, image_subfolder = 'simpsons_dataset', validation_size = 0.5):
+def process_annotations(basedir, image_subfolder = 'simpsons_dataset', validation_size = VALIDATION_SIZE):
     print('---- Annotation Processing Params ----')
     print(f'Number of training classes limit: {CLASS_LIMIT}')   
     print(f'Training size: {1 - validation_size}')

--- a/dataset/simpson.py
+++ b/dataset/simpson.py
@@ -39,7 +39,7 @@ class SimpsonDemo(DatasetSplit):
 
 
 
-def process_annotations(basedir, image_subfolder = 'simpsons_dataset', validation_size = 0.2):
+def process_annotations(basedir, image_subfolder = 'simpsons_dataset', validation_size = 0.99):
     # write the final annotation to two separate files
     annotation_file = os.path.join(basedir, "annotation.txt")
     classes_count = {}
@@ -90,7 +90,7 @@ def process_annotations(basedir, image_subfolder = 'simpsons_dataset', validatio
                 all_imgs[filename]['class'] = [class_mapping[class_name]]
 
                 # determine train or validation set 
-                validation_threshold = int(validation_size * 100)
+                validation_threshold = int(validation_size * 100) - 1
                 if np.random.randint(0, 100) > validation_threshold:
                     all_imgs[filename]['imageset'] = 'train'
                 else:
@@ -118,10 +118,10 @@ def process_annotations(basedir, image_subfolder = 'simpsons_dataset', validatio
             'val': val_meta,
         }, fw, indent=4)
 
-def register_simpson(basedir):
+def register_simpson(basedir, process_raw_annotations=True):
     # TODO: fix major bug cause if you process annotations here then you cant register other data sets to train them!!!!
     if basedir.split('/')[-1] != 'simpson': return
-    process_annotations(basedir) 
+    if process_raw_annotations: process_annotations(basedir) 
     json_file = os.path.join(basedir, "annotations.json")
     with open(json_file) as f:
         obj = json.load(f)

--- a/dataset/simpson.py
+++ b/dataset/simpson.py
@@ -1,24 +1,13 @@
-import math
 import os
 import numpy as np
 import json
 from dataset import DatasetSplit, DatasetRegistry
-import random
-import argparse
-from viz import draw_annotation
-from config import config as cfg
-from PIL import Image
-import cv2
+from parse_simpson import IMAGE_SUBFOLDER
 
 '''
     Included an example.simpson.ipynb for reference (ran on colab)
 '''
 
-# Default configs
-CLASS_LIMIT = 99 # simpson dataset have 18 classes
-VALIDATION_SIZE = 0.5 # minium validation size for 19 classed to be validly trained
-BASE_DIR = './data/simpson'
-IMAGE_SUBFOLDER = 'simpsons_dataset'
 
 '''
     ! IMPORTANT TRAINING NOTE:
@@ -85,109 +74,6 @@ class SimpsonDemo(DatasetSplit):
 
 
 
-def split_train_val(all_imgs, classes_count, validation_size):
-    '''
-        This function will try balance of classes
-        1. train size is based on the count of the smallest class (class with least samples)
-            Meaning if train_size is 0.1 and smallest class have 10 samples then
-            -> We take 1 sample from each class of the training set
-        2. This ensure a kind-of-balance and uniform distribution
-        3. And also no empty training class samples
-    '''
-    min_size,  _ = max(zip(classes_count.values(), classes_count.keys()))
-    train_threshold = math.ceil((1 - validation_size) * min_size)
-    training_counter = {key : train_threshold for key in classes_count.keys()}
-    train = []
-    val = []
-    
-    image_keys = list(all_imgs.keys())
-    random.shuffle(image_keys)
-    for key in image_keys:
-        classname = all_imgs[key]['classname'][0]
-        if training_counter[classname] >= 0:
-            train.append(all_imgs[key])
-            training_counter[classname] -= 1
-        else:
-            val.append(all_imgs[key])
-
-    print(f'Classes count: {len(classes_count)}')
-    print(f'Train size: {len(train)}, validation size: {len(val)}')
-    return train, val
-
-'''
-    Parse annotation.txt and write to annotation.json with train/val split for easy
-        training without actually splitting the dataset into train/val folder
-
-    NOTE: process_annotations's
-        bounding box parsing is based on code from the following project
-    https://github.com/duckrabbits/ObjectDetection/blob/master/model/parser.py
-'''
-def process_annotations(
-        basedir, 
-        class_limit,
-        validation_size,
-        image_subfolder=IMAGE_SUBFOLDER
-    ):
-    print(f'Number of training classes limit: {class_limit}')   
-    print(f'Training size: {1 - validation_size}')
-    
-    annotation_file = os.path.join(basedir, "annotation.txt")
-    classes_count = {}
-    class_mapping = {}
-    all_imgs = {}
-
-    classes_count['BG'] = 0
-    class_mapping['BG'] = 0
-
-    with open(annotation_file,'r') as f:
-        for line in f:
-            line_split = line.strip().split(',')
-            (filename,x1,y1,x2,y2,class_name) = line_split
-            x1, y1, x2, y2 = [int(x) + 0.5 for x in [x1, y1, x2, y2]]
-
-            x1, x2 = min(x1,x2), max(x1,x2)
-            y1, y2 = min(y1,y2), max(y1,y2)
-            #! MAKE SURE BOUNDING BOX IS VALID
-            area = (x2 - x1) * (y2 - y1)
-
-            if area <= 0: continue
-            
-            #! Remove leading '/character' or '/character2' in filename
-            filename = '/'.join(filename.split('/')[2:])
-            filename = os.path.join(basedir, image_subfolder, filename) 
-
-
-
-            if class_name not in class_mapping:
-                if len(class_mapping) > class_limit: continue
-                class_mapping[class_name] = len(class_mapping)
-                # this means first class is 1, second is 2, ...
-            
-            # update class count
-            if class_name not in classes_count:
-                classes_count[class_name] = 1
-            else:
-                classes_count[class_name] += 1
-
-            if filename not in all_imgs:
-                all_imgs[filename] = {}
-                all_imgs[filename]['file_name'] = filename
-                all_imgs[filename]['boxes'] = [[x1,y1, x2, y2]]
-                all_imgs[filename]['class'] = [class_mapping[class_name]]
-                all_imgs[filename]['classname'] = [class_name]
-
-        train_meta, val_meta = split_train_val(all_imgs, classes_count, validation_size)
-
-    # write to file
-    with open(os.path.join(basedir, 'annotations.json'), 'w') as fw:
-        json.dump({
-            'classes' : {
-                'count' : classes_count,
-                'mapping' : class_mapping
-            },
-            'train': train_meta, 
-            'val': val_meta,
-        }, fw, indent=4)
 
 def register_simpson(basedir):
     try:
@@ -203,60 +89,3 @@ def register_simpson(basedir):
         print('WRN: If your not training/testing on simpson dataset, ignore this error!')
         print(e)
         print('----')
-
-def test_data_visuals(basedir, visualize_subfolder = 'temp_output'):
-    json_file = os.path.join(basedir, "annotations.json")
-    with open(json_file) as f:
-        obj = json.load(f)
-    class_names = list(obj['classes']['mapping'].keys())
-
-    #! This is for the draw_annotation function to know our classes
-    cfg.DATA.CLASS_NAMES = class_names 
-    
-    roidbs = SimpsonDemo(basedir, "train").training_roidbs()
-
-    visualization_folder = os.path.join(basedir, visualize_subfolder)
-    if not os.path.isdir(visualization_folder): os.mkdir(visualization_folder)
-
-    visual_percentage = 0.01
-
-    for idx, r in enumerate(roidbs):
-        im = cv2.imread(r["file_name"])
-        
-        vis = draw_annotation(im, r["boxes"], r["class"])
-
-        if np.random.randint(0, 100) < (visual_percentage * 100):
-            visual_name = f'{idx}.png'
-            img = Image.fromarray(vis, 'RGB')
-            output_path = os.path.join(visualization_folder, visual_name)
-            img.save(output_path)
-            print('File: ', r['file_name'], ' visualized as: ', visual_name)
-
-    print('Example data visualizations are in ', visualization_folder)
-
-
-if __name__ == '__main__':
-    parser = argparse.ArgumentParser()
-    parser.add_argument(
-        '--basedir', help='Dataset directory',
-        type=str, required=False, default=BASE_DIR
-    )
-    parser.add_argument(
-        '--class-limit', help='maximum number of classes to parse and later use in training/prediction',
-        type=int, required=False, default=CLASS_LIMIT
-    )
-    parser.add_argument(
-        '--validation-size', help='size of the dataset to use for validation (0 < x < 1)',
-        type=float, required=False, default=VALIDATION_SIZE
-    )
-    parser.add_argument(
-        '--visualize', help='If used, small part of the training dataset will be visualized in a subfolder inside the dataset base directory',
-        action='store_true'
-    )
-    args = parser.parse_args()
-    
-    # Main part
-    process_annotations(args.basedir, args.class_limit, args.validation_size)
-
-    if args.visualize:
-        test_data_visuals(args.basedir)

--- a/dataset/simpson.py
+++ b/dataset/simpson.py
@@ -13,6 +13,28 @@ from config import config as cfg # TODO: remove later
 # CLASS_LIMIT = 10
 CLASS_LIMIT = 99
 
+'''
+    ! IMPORTANT TRAINING NOTE:
+        FOLLOW THESE GUIDELINES IF YOU LIKE THE MODEL TO MAKE ANY PROPER PREDICTIONS AT ALL.
+        -- these are from my own experiment with the model and simpson dataset (very large with lots of classes) --
+    1. Data size is very important: the more classes are trained, the MORE DATA NEEDED
+        Successful train on:
+        - 2 classes -> 0.02 train size
+        - 5 classes -> 0.05 train size
+        - 10 classes -> 0.2 train size
+        - 18 (all) classes -> 0.8 train size
+    2. Training should at least pass through the whole training set ONCE.
+        So pay attention to `TRAIN.LR_SCHEDULE`
+        And try to make sure that (in the logged output) -> "Total passes of the training set is:" >= 1
+    3. If your training metrics starts to show results as NAN -> Likely failed and will give no predictions
+        Ex: total_cost: 0.34688
+            wd_cost: 0.1622
+        params should be numbers like so, not nan
+    4. Epoch size `TRAIN.STEPS_PER_EPOCH` is not that important
+        But model saving and other callbacks will be called periodically based on epoch, 
+        so smaller value means more checkpoint saving and takes more time
+    
+'''
 class SimpsonDemo(DatasetSplit):
     def __init__(self, base_dir, split, image_subfolder = 'simpsons_dataset'):
         assert split in ["train", "val"]
@@ -37,12 +59,13 @@ class SimpsonDemo(DatasetSplit):
         
         result = list(formated)
         print('Example roidb: ', result[0])
+        # {'file_name': './data/balloon/train/34020010494_e5cb88e1c4_k.jpg', 'boxes': array([[ 994.5,  619.5, 1445.5, 1166.5]], dtype=float32), 'class': array([1], dtype=int32), 'is_crowd': array([0], dtype=int8)}
         return result
 
 
 
 # def process_annotations(basedir, image_subfolder = 'simpsons_dataset', validation_size = 0.7):
-def process_annotations(basedir, image_subfolder = 'simpsons_dataset', validation_size = 0.2):
+def process_annotations(basedir, image_subfolder = 'simpsons_dataset', validation_size = 0.5):
     # write the final annotation to two separate files
     annotation_file = os.path.join(basedir, "annotation.txt")
     classes_count = {}
@@ -53,8 +76,6 @@ def process_annotations(basedir, image_subfolder = 'simpsons_dataset', validatio
     classes_count['BG'] = 0
     class_mapping['BG'] = 0
 
-    # {'file_name': './data/simpson/simpsons_dataset/abraham_grampa_simpson/pic_0000.jpg', 'boxes': array([[52., 72., 57., 72.]], dtype=float32), 'class': array([1], dtype=int32), 'is_crowd': array([0], dtype=int8)}
-    # {'file_name': './data/balloon/train/34020010494_e5cb88e1c4_k.jpg', 'boxes': array([[ 994.5,  619.5, 1445.5, 1166.5]], dtype=float32), 'class': array([1], dtype=int32), 'is_crowd': array([0], dtype=int8)}
     with open(annotation_file,'r') as f:
         print('Parsing annotation files')
         for line in f:

--- a/dataset/simpson.py
+++ b/dataset/simpson.py
@@ -9,6 +9,7 @@ from config import config as cfg # TODO: remove later
 
 # Stolen link: https://github.com/duckrabbits/ObjectDetection/blob/master/model/parser.py
 
+CLASS_LIMIT = 2
 
 class SimpsonDemo(DatasetSplit):
     def __init__(self, base_dir, split, image_subfolder = 'simpsons_dataset'):
@@ -69,15 +70,18 @@ def process_annotations(basedir, image_subfolder = 'simpsons_dataset', validatio
             filename = '/'.join(filename.split('/')[2:])
             filename = os.path.join(basedir, image_subfolder, filename) 
 
+
+
+            if class_name not in class_mapping:
+                if len(class_mapping) > CLASS_LIMIT: continue
+                class_mapping[class_name] = len(class_mapping)
+                # this means first class is 1, second is 2, ...
+            
             # update class count
             if class_name not in classes_count:
                 classes_count[class_name] = 1
             else:
                 classes_count[class_name] += 1
-
-            if class_name not in class_mapping:
-                class_mapping[class_name] = len(class_mapping)
-                # this means first class is 1, second is 2, ...
 
             if filename not in all_imgs:
                 all_imgs[filename] = {}

--- a/dataset/simpson.py
+++ b/dataset/simpson.py
@@ -99,7 +99,7 @@ def process_annotations(basedir, image_subfolder = 'simpsons_dataset', validatio
         train_meta = []
         val_meta = []
         
-        image_keys = all_imgs.keys()
+        image_keys = list(all_imgs.keys())
         random.shuffle(image_keys)
         for key in image_keys:
             classname = all_imgs[key]['classname'][0]

--- a/dataset/simpson.py
+++ b/dataset/simpson.py
@@ -34,8 +34,10 @@ from dataset import DatasetSplit, DatasetRegistry
         - Train with proper TRAIN.STEPS_PER_EPOCH and see results
 '''
 
+IMAGE_SUBFOLDER = 'simpsons_dataset'
+
 class SimpsonDemo(DatasetSplit):
-    def __init__(self, base_dir, split, image_subfolder):
+    def __init__(self, base_dir, split, image_subfolder=IMAGE_SUBFOLDER):
         assert split in ["train", "val"]
         base_dir = os.path.expanduser(base_dir)
         self.imgdir = os.path.join(base_dir, image_subfolder)

--- a/dataset/simpson.py
+++ b/dataset/simpson.py
@@ -43,8 +43,9 @@ def process_annotations(basedir, image_subfolder = 'simpsons_dataset', validatio
     class_mapping = {}
     all_imgs = {}
 
-    # classes_count['BG'] = 0
-    # class_mapping['BG'] = 0
+    # TODO: if you want to remove this, then you must also change how classes are added to frame work
+    classes_count['BG'] = 0
+    class_mapping['BG'] = 0
 
 
     with open(annotation_file,'r') as f:
@@ -72,7 +73,7 @@ def process_annotations(basedir, image_subfolder = 'simpsons_dataset', validatio
                 classes_count[class_name] += 1
 
             if class_name not in class_mapping:
-                class_mapping[class_name] = len(class_mapping) + 1
+                class_mapping[class_name] = len(class_mapping)
                 # this means first class is 1, second is 2, ...
 
             if filename not in all_imgs:

--- a/predict.py
+++ b/predict.py
@@ -93,9 +93,15 @@ def do_evaluate(pred_config, output_file):
         DatasetRegistry.get(dataset).eval_inference_results(all_results, output)
 
 def predict_folder(predictor, folder_name):
+    valid_results = []
     for file in os.listdir(folder_name):
         file_path = os.path.join(folder_name, file)
-        do_predict(predictor, file_path)
+        result = do_predict(predictor, file_path)
+        if result: valid_results.append(result)
+    
+    if not valid_results:
+        logger.warning('NO VALID RESULT IN THE WHOLE PREDICTION SET')
+
 
 def do_predict(pred_func, input_file, output_folder = './prediction', show=False):
     if not os.path.isdir(output_folder): os.mkdir(output_folder)
@@ -114,7 +120,7 @@ def do_predict(pred_func, input_file, output_folder = './prediction', show=False
     cv2.imwrite(output_path, viz)
     logger.info("Inference output for {} written to {}".format(input_file, output_path))
     if show: tpviz.interactive_imshow(viz)
-
+    return results
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser()

--- a/predict.py
+++ b/predict.py
@@ -102,6 +102,8 @@ def do_predict(pred_func, input_file, output_folder = './prediction', show=False
 
     img = cv2.imread(input_file, cv2.IMREAD_COLOR)
     results = predict_image(img, pred_func)
+    logger.info(f'Prediction results: {results}')
+    if not results: logger.warning('Empty predictions!')
     if cfg.MODE_MASK:
         final = draw_final_outputs_blackwhite(img, results)
     else:

--- a/predict.py
+++ b/predict.py
@@ -15,7 +15,7 @@ from tensorpack.tfutils import SmartInit, get_tf_version_tuple
 from tensorpack.tfutils.export import ModelExporter
 from tensorpack.utils import fs, logger
 
-from dataset import DatasetRegistry, register_coco, register_balloon
+from dataset import DatasetRegistry, register_coco, register_balloon, register_simpson
 from config import config as cfg
 from config import finalize_configs
 from data import get_eval_dataflow, get_train_dataflow
@@ -125,6 +125,7 @@ if __name__ == '__main__':
         cfg.update_args(args.config)
     register_coco(cfg.DATA.BASEDIR)  # add COCO datasets to the registry
     register_balloon(cfg.DATA.BASEDIR)
+    register_simpson(cfg.DATA.BASEDIR)
 
     MODEL = ResNetFPNModel() if cfg.MODE_FPN else ResNetC4Model()
 
@@ -160,10 +161,10 @@ if __name__ == '__main__':
             assert args.evaluate.endswith('.json'), args.evaluate
             do_evaluate(predcfg, args.evaluate)
         elif args.benchmark:
-            df = get_eval_dataflow(cfg.DATA.VAL[0])
-            df.reset_state()
+            obj = get_eval_dataflow(cfg.DATA.VAL[0])
+            obj.reset_state()
             predictor = OfflinePredictor(predcfg)
-            for _, img in enumerate(tqdm.tqdm(df, total=len(df), smoothing=0.5)):
+            for _, img in enumerate(tqdm.tqdm(obj, total=len(obj), smoothing=0.5)):
                 # This includes post-processing time, which is done on CPU and not optimized
                 # To exclude it, modify `predict_image`.
                 predict_image(img[0], predictor)

--- a/predict.py
+++ b/predict.py
@@ -136,7 +136,7 @@ if __name__ == '__main__':
         cfg.update_args(args.config)
     register_coco(cfg.DATA.BASEDIR)  # add COCO datasets to the registry
     register_balloon(cfg.DATA.BASEDIR)
-    register_simpson(cfg.DATA.BASEDIR)
+    register_simpson(cfg.DATA.BASEDIR, process_raw_annotations=False)
 
     MODEL = ResNetFPNModel() if cfg.MODE_FPN else ResNetC4Model()
 

--- a/predict.py
+++ b/predict.py
@@ -97,7 +97,7 @@ def predict_folder(predictor, folder_name):
         file_path = os.path.join(folder_name, file)
         do_predict(predictor, file_path)
 
-def do_predict(pred_func, input_file, output_folder = './prediction'):
+def do_predict(pred_func, input_file, output_folder = './prediction', show=False):
     if not os.path.isdir(output_folder): os.mkdir(output_folder)
 
     img = cv2.imread(input_file, cv2.IMREAD_COLOR)
@@ -112,7 +112,7 @@ def do_predict(pred_func, input_file, output_folder = './prediction'):
     output_path = os.path.join(output_folder, output_filename)
     cv2.imwrite(output_path, viz)
     logger.info("Inference output for {} written to {}".format(input_file, output_path))
-    tpviz.interactive_imshow(viz)
+    if show: tpviz.interactive_imshow(viz)
 
 
 if __name__ == '__main__':

--- a/predict.py
+++ b/predict.py
@@ -108,7 +108,8 @@ def do_predict(pred_func, input_file, output_folder, show=False):
 
     img = cv2.imread(input_file, cv2.IMREAD_COLOR)
     results = predict_image(img, pred_func)
-    if not results: logger.warning(f'Empty predictions for image file: {input_file}')
+    if not results: logger.warning(f'Empty predictions for image file: {input_file.split("/")[-1]}')
+
     if cfg.MODE_MASK:
         final = draw_final_outputs_blackwhite(img, results)
     else:

--- a/predict.py
+++ b/predict.py
@@ -102,8 +102,7 @@ def do_predict(pred_func, input_file, output_folder = './prediction', show=False
 
     img = cv2.imread(input_file, cv2.IMREAD_COLOR)
     results = predict_image(img, pred_func)
-    logger.info(f'Prediction results: {results}')
-    if not results: logger.warning('Empty predictions!')
+    if not results: logger.warning(f'Empty predictions for image file: {input_file}')
     if cfg.MODE_MASK:
         final = draw_final_outputs_blackwhite(img, results)
     else:

--- a/predict.py
+++ b/predict.py
@@ -145,7 +145,7 @@ if __name__ == '__main__':
         cfg.update_args(args.config)
     register_coco(cfg.DATA.BASEDIR)  # add COCO datasets to the registry
     register_balloon(cfg.DATA.BASEDIR)
-    register_simpson(cfg.DATA.BASEDIR, process_raw_annotations=False) # this assumes that you already parsed the simpson annotations
+    register_simpson(cfg.DATA.BASEDIR)
 
     MODEL = ResNetFPNModel() if cfg.MODE_FPN else ResNetC4Model()
 

--- a/predict.py
+++ b/predict.py
@@ -182,10 +182,10 @@ if __name__ == '__main__':
             assert args.evaluate.endswith('.json'), args.evaluate
             do_evaluate(predcfg, args.evaluate)
         elif args.benchmark:
-            obj = get_eval_dataflow(cfg.DATA.VAL[0])
-            obj.reset_state()
+            df = get_eval_dataflow(cfg.DATA.VAL[0])
+            df.reset_state()
             predictor = OfflinePredictor(predcfg)
-            for _, img in enumerate(tqdm.tqdm(obj, total=len(obj), smoothing=0.5)):
+            for _, img in enumerate(tqdm.tqdm(df, total=len(df), smoothing=0.5)):
                 # This includes post-processing time, which is done on CPU and not optimized
                 # To exclude it, modify `predict_image`.
                 predict_image(img[0], predictor)

--- a/predict.py
+++ b/predict.py
@@ -98,6 +98,8 @@ def predict_folder(predictor, folder_name):
         do_predict(predictor, file_path)
 
 def do_predict(pred_func, input_file, output_folder = './prediction'):
+    if not os.path.isdir(output_folder): os.mkdir(output_folder)
+
     img = cv2.imread(input_file, cv2.IMREAD_COLOR)
     results = predict_image(img, pred_func)
     if cfg.MODE_MASK:

--- a/predict.py
+++ b/predict.py
@@ -100,7 +100,7 @@ def predict_folder(predictor, folder_name):
         if result: valid_results.append(result)
     
     if not valid_results:
-        logger.warning('NO VALID RESULT IN THE WHOLE PREDICTION SET')
+        logger.warning('NO VALID RESULT IN THE WHOLE PREDICTION SET, your training might be invalid')
 
 
 def do_predict(pred_func, input_file, output_folder = './prediction', show=False):
@@ -119,6 +119,8 @@ def do_predict(pred_func, input_file, output_folder = './prediction', show=False
     output_path = os.path.join(output_folder, output_filename)
     cv2.imwrite(output_path, viz)
     logger.info("Inference output for {} written to {}".format(input_file, output_path))
+
+    # NOTE: this to suppress prediction error when ran on Colab since interactive visuals cannot be drawn there
     if show: tpviz.interactive_imshow(viz)
     return results
 
@@ -141,7 +143,7 @@ if __name__ == '__main__':
         cfg.update_args(args.config)
     register_coco(cfg.DATA.BASEDIR)  # add COCO datasets to the registry
     register_balloon(cfg.DATA.BASEDIR)
-    register_simpson(cfg.DATA.BASEDIR, process_raw_annotations=False)
+    register_simpson(cfg.DATA.BASEDIR, process_raw_annotations=False) # this assumes that you already parsed the simpson annotations
 
     MODEL = ResNetFPNModel() if cfg.MODE_FPN else ResNetC4Model()
 

--- a/predict.py
+++ b/predict.py
@@ -138,7 +138,7 @@ if __name__ == '__main__':
                         nargs='+')
     parser.add_argument('--output-pb', help='Save a model to .pb')
     parser.add_argument('--output-serving', help='Save a model to serving file')
-    parser.add_argument('--predict-folder', help='Predict a whole folder')
+    parser.add_argument('--predict-folder', help='Predict a whole folder', required=False, type=str, default=None)
     parser.add_argument('--output-folder', help='Output folder for predictions', required=False, type=str, default='./prediction')
     args = parser.parse_args()
     if args.config:

--- a/train.py
+++ b/train.py
@@ -103,7 +103,7 @@ if __name__ == '__main__':
             session_init = SmartInit(cfg.BACKBONE.WEIGHTS)
 
     MAX_EPOCH = cfg.TRAIN.LR_SCHEDULE[-1] * factor // stepnum
-    if cfg.max_epochs: MAX_EPOCH = cfg.max_epochs
+    if args.max_epochs: MAX_EPOCH = args.max_epochs
     logger.info(f'MAX EPOCH= {MAX_EPOCH}')
     traincfg = TrainConfig(
         model=MODEL,

--- a/train.py
+++ b/train.py
@@ -103,7 +103,7 @@ if __name__ == '__main__':
             session_init = SmartInit(cfg.BACKBONE.WEIGHTS)
 
     MAX_EPOCH = cfg.TRAIN.LR_SCHEDULE[-1] * factor // stepnum
-    if cfg.max_epochs: MAX_EPOCH = cfg.max_epoch
+    if cfg.max_epochs: MAX_EPOCH = cfg.max_epochs
     logger.info(f'MAX EPOCH= {MAX_EPOCH}')
     traincfg = TrainConfig(
         model=MODEL,

--- a/train.py
+++ b/train.py
@@ -6,7 +6,7 @@ import argparse
 from tensorpack import *
 from tensorpack.tfutils import collect_env_info
 
-from dataset import register_coco, register_balloon
+from dataset import register_coco, register_balloon, register_simpson
 from config import config as cfg
 from config import finalize_configs
 from data import get_train_dataflow
@@ -37,7 +37,7 @@ if __name__ == '__main__':
         cfg.update_args(args.config)
     register_coco(cfg.DATA.BASEDIR)  # add COCO datasets to the registry
     register_balloon(cfg.DATA.BASEDIR)  # add the demo balloon datasets to the registry
-
+    register_simpson(cfg.DATA.BASEDIR)
     # Setup logging ...
     is_horovod = cfg.TRAINER == 'horovod'
     if is_horovod:

--- a/train.py
+++ b/train.py
@@ -31,7 +31,7 @@ if __name__ == '__main__':
     parser.add_argument('--logdir', help='Log directory. Will remove the old one if already exists.',
                         default='train_log/maskrcnn')
     parser.add_argument('--config', help="A list of KEY=VALUE to overwrite those defined in config.py", nargs='+')
-
+    parser.add_argument('--max-epochs', help='Maximum number of training epoch (OVERRIDE)')
     args = parser.parse_args()
     if args.config:
         cfg.update_args(args.config)
@@ -103,6 +103,7 @@ if __name__ == '__main__':
             session_init = SmartInit(cfg.BACKBONE.WEIGHTS)
 
     MAX_EPOCH = cfg.TRAIN.LR_SCHEDULE[-1] * factor // stepnum
+    if cfg.max_epoch: MAX_EPOCH = cfg.max_epoch
     logger.info(f'MAX EPOCH= {MAX_EPOCH}')
     traincfg = TrainConfig(
         model=MODEL,

--- a/train.py
+++ b/train.py
@@ -19,7 +19,8 @@ try:
 except ImportError:
     pass
 
-
+# TODO: add a validate prediction function to test if prediction is found while trainging   
+# TODO: rmb to add option to save output to file OR NOT!!
 if __name__ == '__main__':
     # "spawn/forkserver" is safer than the default "fork" method and
     # produce more deterministic behavior & memory saving
@@ -32,6 +33,9 @@ if __name__ == '__main__':
                         default='train_log/maskrcnn')
     parser.add_argument('--config', help="A list of KEY=VALUE to overwrite those defined in config.py", nargs='+')
     parser.add_argument('--max-epochs', help='Maximum number of training epoch (OVERRIDE)', type=int, required=False, default=None)
+
+    # TODO: complex, later
+    # parser.add_argument('--test-predictions', help='A folder to test predictions on each EPOCH', type=str, required=False, default=None)
     args = parser.parse_args()
     if args.config:
         cfg.update_args(args.config)

--- a/train.py
+++ b/train.py
@@ -103,7 +103,7 @@ if __name__ == '__main__':
             session_init = SmartInit(cfg.BACKBONE.WEIGHTS)
 
     MAX_EPOCH = cfg.TRAIN.LR_SCHEDULE[-1] * factor // stepnum
-    if cfg.max_epoch: MAX_EPOCH = cfg.max_epoch
+    if cfg.max_epochs: MAX_EPOCH = cfg.max_epoch
     logger.info(f'MAX EPOCH= {MAX_EPOCH}')
     traincfg = TrainConfig(
         model=MODEL,

--- a/train.py
+++ b/train.py
@@ -19,8 +19,7 @@ try:
 except ImportError:
     pass
 
-# TODO: add a validate prediction function to test if prediction is found while trainging   
-# TODO: rmb to add option to save output to file OR NOT!!
+
 if __name__ == '__main__':
     # "spawn/forkserver" is safer than the default "fork" method and
     # produce more deterministic behavior & memory saving

--- a/train.py
+++ b/train.py
@@ -34,14 +34,12 @@ if __name__ == '__main__':
     parser.add_argument('--config', help="A list of KEY=VALUE to overwrite those defined in config.py", nargs='+')
     parser.add_argument('--max-epochs', help='Maximum number of training epoch (OVERRIDE)', type=int, required=False, default=None)
 
-    # TODO: complex, later
-    # parser.add_argument('--test-predictions', help='A folder to test predictions on each EPOCH', type=str, required=False, default=None)
     args = parser.parse_args()
     if args.config:
         cfg.update_args(args.config)
     register_coco(cfg.DATA.BASEDIR)  # add COCO datasets to the registry
     register_balloon(cfg.DATA.BASEDIR)  # add the demo balloon datasets to the registry
-    register_simpson(cfg.DATA.BASEDIR)
+    register_simpson(cfg.DATA.BASEDIR) # try to add the simpson dataset (keyword try)
     # Setup logging ...
     is_horovod = cfg.TRAINER == 'horovod'
     if is_horovod:
@@ -73,7 +71,6 @@ if __name__ == '__main__':
     train_dataflow = get_train_dataflow()
     # This is what's commonly referred to as "epochs"
     total_passes = cfg.TRAIN.LR_SCHEDULE[-1] * 8 / train_dataflow.size()
-    logger.info("Total passes of the training set is: {:.5g}".format(total_passes))
 
     # Create callbacks ...
     callbacks = [
@@ -108,7 +105,7 @@ if __name__ == '__main__':
 
     MAX_EPOCH = cfg.TRAIN.LR_SCHEDULE[-1] * factor // stepnum
     if args.max_epochs: MAX_EPOCH = args.max_epochs
-    logger.info(f'MAX EPOCH= {MAX_EPOCH}')
+    
     traincfg = TrainConfig(
         model=MODEL,
         data=QueueInput(train_dataflow),
@@ -118,6 +115,10 @@ if __name__ == '__main__':
         session_init=session_init,
         starting_epoch=cfg.TRAIN.STARTING_EPOCH
     )
+
+    logger.info(f'MAX EPOCH= {MAX_EPOCH}')
+    logger.info(f'Epoch size - Step num - samples per epoch: {stepnum}')
+    logger.info("Total passes of the training set is: {:.5g}".format(total_passes))
 
     if is_horovod:
         trainer = HorovodTrainer(average=False)

--- a/train.py
+++ b/train.py
@@ -102,12 +102,14 @@ if __name__ == '__main__':
         else:
             session_init = SmartInit(cfg.BACKBONE.WEIGHTS)
 
+    MAX_EPOCH = cfg.TRAIN.LR_SCHEDULE[-1] * factor // stepnum
+    logger.info(f'MAX EPOCH= {MAX_EPOCH}')
     traincfg = TrainConfig(
         model=MODEL,
         data=QueueInput(train_dataflow),
         callbacks=callbacks,
         steps_per_epoch=stepnum,
-        max_epoch=cfg.TRAIN.LR_SCHEDULE[-1] * factor // stepnum,
+        max_epoch=MAX_EPOCH,
         session_init=session_init,
         starting_epoch=cfg.TRAIN.STARTING_EPOCH
     )

--- a/train.py
+++ b/train.py
@@ -31,7 +31,7 @@ if __name__ == '__main__':
     parser.add_argument('--logdir', help='Log directory. Will remove the old one if already exists.',
                         default='train_log/maskrcnn')
     parser.add_argument('--config', help="A list of KEY=VALUE to overwrite those defined in config.py", nargs='+')
-    parser.add_argument('--max-epochs', help='Maximum number of training epoch (OVERRIDE)')
+    parser.add_argument('--max-epochs', help='Maximum number of training epoch (OVERRIDE)', type=int, required=False, default=None)
     args = parser.parse_args()
     if args.config:
         cfg.update_args(args.config)


### PR DESCRIPTION
# Description
- Adding `simpson` dataset to `tensorboard` F-RCNN code
- And running example/experiment of transfer learning 
- Some moddifications to original code (minor) mostly for easier experimenting
- How to use?
```[bash]
# after getting code, dependencies, ..., parse the dataset
python -m dataset.parse_simpson --validation-size 0.5
# then train model
python ./train.py --config DATA.BASEDIR=./data/simpson MODE_FPN=True \
  MODE_MASK=False\
	TRAIN.STEPS_PER_EPOCH=1000 \
	"DATA.VAL=('simpson_val',)"  "DATA.TRAIN=('simpson_train',)" \
	TRAIN.BASE_LR=1e-1 TRAIN.EVAL_PERIOD=0 "TRAIN.LR_SCHEDULE=[800]" \
	"PREPROC.TRAIN_SHORT_EDGE_SIZE=[600,1200]" TRAIN.CHECKPOINT_PERIOD=1 DATA.NUM_WORKERS=1 \
	--load COCO-MaskRCNN-R50FPN2x.npz --logdir train_log/simpson
```
Full example in `simpson.ipynb`

# Main changes

### `train.py`
- Added logging for 
    1. `Max Epoch`: Maximum number of training epoches that's gonna happen
    2. `Epoch Size`: The total number of images trained in one epoch, this could be more than one `pass` through your dataset. Meaning that if your dataset is sized `10` and epoch size is `100`, then the dataset is aproximately trained 10 times in one epoch.
    3. `Total Passes`: As mentioned in the previous point, this is the total passes that the whole training procedure finish over your dataset. (How many times your dataset is repeatedly trained in training)
    ```
        total_passes ~= epoch_size * max_epoch
    ````
- Add option to override `MAX_EPOCH` by using `--max-epoch` argument (debuging and experimental purpose mostly)
- And of course register `simpson` dataset to framework, including parsing the annotation file

### `predict.py`
- FIles are now predicted and saved into a separate folder, with same name as original file, use `--output-folder` option
- Interactive visualization of prediction results when using `--predict` is disable as it does not work on Colab
- Add option to predict a whole folder and output to another folder
- Added logging to know if prediction result does not have any bouding box (empty prediction)
- And of course added registering `simpson` dataset to the model framework (this **DOES NOT** include parsing the annotation file)

### `dataset/parse_simpson.py`
- This is for parsing the simpson dataset and annotations into usable format for model training
- Also splits dataset into train/validation
- This is done by reading the `annotation.txt` file and the images then parse all the data into `annotation.json` file with the correct format

### `dataset/simpson.py`
- Load the simpson data with the help of the parsed `annotation.json` file
- Register the simpson dataset to `tensorpack` model framework for training/prediction

### `simpson.ipynb`
- Example code run on simpson dataset on google colab
# Notes
- Refer to `dataset/simpson.py` and `dataset/parse_simson.py` for more notes about training simpson